### PR TITLE
Fix Munki update progress and change custom actions config

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -27,7 +27,6 @@ public class App : Application
     public override void OnFrameworkInitializationCompleted()
     {
         RegisterAppServices();
-
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             DataContext = ServiceProvider.GetRequiredService<MainWindowViewModel>();
@@ -39,26 +38,28 @@ public class App : Application
 
         DataContext = ServiceProvider.GetRequiredService<MainWindowViewModel>();
 
-        if (Config.Actions.Count > 0)
+        if (Config.Actions != null && Config.Actions.Count > 0)
         {
             // Create the main "Actions" menu item
             var actionsMenuItem = new NativeMenuItem { Header = "Actions ✅" };
             actionsMenuItem.Menu = new NativeMenu();
 
             // Iterate over the Config.Actions and add them as sub-items
-            foreach (var item in Config.Actions)
-            {
-                var subItem = new NativeMenuItem
+            foreach (var action in Config.Actions)
+                if (action.Value.TryGetValue("Name", out var name) &&
+                    action.Value.TryGetValue("Command", out var command))
                 {
-                    Header = item.Key,
-                    Command = new RelayCommand(() =>
+                    var subItem = new NativeMenuItem
                     {
-                        var actionsService = ServiceProvider.GetRequiredService<ActionsService>();
-                        actionsService.RunCommandWithoutOutput(item.Value);
-                    })
-                };
-                actionsMenuItem.Menu.Items.Add(subItem);
-            }
+                        Header = name,
+                        Command = new RelayCommand(() =>
+                        {
+                            var actionsService = ServiceProvider.GetRequiredService<ActionsService>();
+                            actionsService.RunCommandWithoutOutput(command);
+                        })
+                    };
+                    actionsMenuItem.Menu.Items.Add(subItem);
+                }
 
             // Insert the main "Actions" menu item at the third position (index 2)
             var trayIcon = TrayIcon.GetIcons(this).First();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2024-05-27
+### Changed
+- Changed the configuration of the custom tray menu actions to use `Name` and `Command` keys for better readability.
+
+### Fixed
+- The Munki update percentage was not being updated correctly in the UI as apps were updated.
+
 ## [1.0.1] - 2024-05-27
 ### Added
 - Added a new configuration option to allow for adding custom actions to the tray menu. This allows for admins to add custom actions to the tray menu for common tasks that the user might perform for support purposes, such as restarting a service or running a script. Example configuration:

--- a/Helpers/AppConfigHelper.cs
+++ b/Helpers/AppConfigHelper.cs
@@ -103,12 +103,22 @@ public class AppConfigHelper
                 case "Actions":
                     if (pref.Value is NSMutableArray actionsArray)
                     {
-                        Config.Actions = new Dictionary<string, string>();
+                        Config.Actions = new Dictionary<string, Dictionary<string, string>>();
                         foreach (var action in actionsArray)
                             if (action is NSDictionary actionDict)
+                            {
+                                var actionEntry = new Dictionary<string, string>();
+                                string actionName = null;
+
                                 foreach (var key in actionDict.Keys)
                                     if (key is NSString actionKey && actionDict[actionKey] is NSString actionValue)
-                                        Config.Actions.Add(actionKey.ToString(), actionValue.ToString());
+                                    {
+                                        if (actionKey.ToString() == "Name") actionName = actionValue.ToString();
+                                        actionEntry[actionKey.ToString()] = actionValue.ToString();
+                                    }
+
+                                if (actionName != null) Config.Actions[actionName] = actionEntry;
+                            }
                     }
 
                     break;

--- a/Info.plist
+++ b/Info.plist
@@ -11,7 +11,7 @@
         <key>CFBundleName</key>
         <string>SupportCompanion</string>
         <key>CFBundleVersion</key>
-        <string>1.0.1</string>
+        <string>1.0.2</string>
         <key>LSMinimumSystemVersion</key>
         <string>10.15</string>
         <key>CFBundleExecutable</key>
@@ -21,7 +21,7 @@
         <key>CFBundlePackageType</key>
         <string>APPL</string>
         <key>CFBundleShortVersionString</key>
-        <string>1.0.1</string>
+        <string>1.0.2</string>
         <key>NSHighResolutionCapable</key>
         <true/>
         <key>LSUIElement</key>

--- a/Models/AppConfiguration.cs
+++ b/Models/AppConfiguration.cs
@@ -39,5 +39,5 @@ public class AppConfiguration
     public Dictionary<string, string> CustomColors { get; set; } = new();
     public bool MunkiMode { get; set; } = true;
     public bool IntuneMode { get; set; }
-    public Dictionary<string, string> Actions { get; set; } = new();
+    public Dictionary<string, Dictionary<string, string>> Actions { get; set; } = new();
 }

--- a/README.md
+++ b/README.md
@@ -130,8 +130,6 @@ To switch from Munki to Intune for application information, add the following ke
           <dict>
             <key>PrimaryColor</key>
             <string>#00A0D0</string>
-          </dict>
-          <dict>
             <key>AccentColor</key>
             <string>#45637A</string>
           </dict>
@@ -139,12 +137,16 @@ To switch from Munki to Intune for application information, add the following ke
         <key>Actions</key>
         <array>
            <dict>
-              <key>Restart clipboard 🥹</key>
-              <string>killall pboard</string>
+               <key>Name</key>
+               <string>Restart clipboard 🥹</string>
+               <key>Command</key>
+               <string>killall pboard</string>
            </dict>
            <dict>
-              <key>Restart Intune Agent ⚡️</key>
-              <string>/usr/bin/osascript -e 'do shell script \"sudo killall IntuneMdmAgent\" with administrator privileges'</string>
+               <key>Name</key>
+               <string>Restart Intune Agent ⚡️</string>
+               <key>Command</key>
+               <string>/usr/bin/osascript -e 'do shell script \"sudo killall IntuneMdmAgent\" with administrator privileges'</string>
            </dict>
         </array>
         <key>NotificationTitle</key>

--- a/ViewModels/MunkiUpdatesViewModel.cs
+++ b/ViewModels/MunkiUpdatesViewModel.cs
@@ -1,4 +1,5 @@
 using Avalonia.Threading;
+using ReactiveUI;
 using SupportCompanion.Interfaces;
 using SupportCompanion.Models;
 using SupportCompanion.Services;
@@ -11,6 +12,8 @@ public class MunkiUpdatesViewModel : ViewModelBase, IWindowStateAware
     private readonly MunkiAppsService _munkiApps;
     private int _installedAppsCount;
     private int _munkiUpdatesCount;
+
+    private MunkiUpdatesModel? _munkiUpdatesInfo;
     private Timer? _timer;
 
     public MunkiUpdatesViewModel(MunkiAppsService munkiApps, LoggerService loggerService)
@@ -24,7 +27,11 @@ public class MunkiUpdatesViewModel : ViewModelBase, IWindowStateAware
         }
     }
 
-    public MunkiUpdatesModel? MunkiUpdatesInfo { get; private set; }
+    public MunkiUpdatesModel? MunkiUpdatesInfo
+    {
+        get => _munkiUpdatesInfo;
+        private set => this.RaiseAndSetIfChanged(ref _munkiUpdatesInfo, value);
+    }
 
     public void OnWindowHidden()
     {


### PR DESCRIPTION
- `Actions` now uses the `Name` and `Command` keys,
```xml
<dict>
	<key>Name</key>
	<string>Restart clipboard 🥹</string>
	<key>Command</key>
	<string>killall pboard</string>
</dict>
```
- Munki update progress now correctly updates the UI as updates are installed.