### PR TITLE
NotificationInterval crashes init

### DIFF
--- a/.github/workflows/build_supportcompanion.yml
+++ b/.github/workflows/build_supportcompanion.yml
@@ -83,7 +83,7 @@ jobs:
             ${{ steps.changelog_reader.outputs.changes }}
 
             # Changes
-            ${{ steps.changelog.outputs.changes }}
+            ${{ steps.changelog.outputs.changelog }}
           files: ${{github.workspace}}/Build/build/*.pkg
 
       - name: Upload packages

--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -16,11 +16,24 @@ public class App : Application
     public static AppConfiguration Config { get; private set; }
     public IServiceProvider ServiceProvider { get; private set; }
 
+    public App()
+    {
+        RegisterAppServices();
+    }
+    
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
         var prefs = new AppConfigHelper();
-        prefs.SetPrefs();
+        try
+        {
+            prefs.SetPrefs();
+        }
+        catch (Exception e)
+        {
+            var logger = ServiceProvider.GetRequiredService<LoggerService>();
+            logger.Log("App initialization", "Error loading preferences: " + e.Message, 2);
+        }
         Config = AppConfigHelper.Config;
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2024-05-28
+### Fixed
+- Notification Interval failed to be cast as an integer, causing the app to crash on initialization. The value is now converted from NSNumber to Int before being used in the app.
+
 ## [1.0.2] - 2024-05-27
 ### Changed
 - Changed the configuration of the custom tray menu actions to use `Name` and `Command` keys for better readability.

--- a/Helpers/AppConfigHelper.cs
+++ b/Helpers/AppConfigHelper.cs
@@ -22,7 +22,7 @@ public class AppConfigHelper
             var preference = CFPreferences.GetAppValue(pref, bundleId);
             if (preference != null) prefs.Add(pref, preference);
         }
-
+        
         foreach (var pref in prefs)
             switch (pref.Key)
             {
@@ -48,7 +48,14 @@ public class AppConfigHelper
                     Config.SupportPhone = pref.Value as NSString;
                     break;
                 case "NotificationInterval":
-                    Config.NotificationInterval = (int)pref.Value;
+                    if (pref.Value is Foundation.NSNumber number)
+                    {
+                        Config.NotificationInterval = number.Int32Value;
+                    }
+                    else if (pref.Value is Foundation.NSString nsString)
+                    {
+                        Config.NotificationInterval = int.Parse(nsString.ToString());
+                    }
                     break;
                 case "NotificationTitle":
                     Config.NotificationTitle = pref.Value as NSString;

--- a/Info.plist
+++ b/Info.plist
@@ -11,7 +11,7 @@
         <key>CFBundleName</key>
         <string>SupportCompanion</string>
         <key>CFBundleVersion</key>
-        <string>1.0.2</string>
+        <string>1.0.3</string>
         <key>LSMinimumSystemVersion</key>
         <string>10.15</string>
         <key>CFBundleExecutable</key>
@@ -21,7 +21,7 @@
         <key>CFBundlePackageType</key>
         <string>APPL</string>
         <key>CFBundleShortVersionString</key>
-        <string>1.0.2</string>
+        <string>1.0.3</string>
         <key>NSHighResolutionCapable</key>
         <true/>
         <key>LSUIElement</key>

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ Many aspects of the app can be configured using MDM profiles, the folloing keys 
 | `BrandColor` | String | Blue | False | Configures the brand color shown in the app, available colors are: Blue, Green, Red, Orange |
 | `SupportPageUrl` | String | None | False | Configures the URL to open when the user clicks on the Get Support button |
 | `ChangePasswordUrl` | String | None | False | Configures the URL to open when the user clicks on the Change Password button |
-| `ChangePasswordMode` | String | local | False | Configures the mode for the Change Password button, available modes are: `local`, `SSOExtension`, `Url` |
+| `ChangePasswordMode` | String | local | False | Configures the mode for the Change Password button, available modes are: `local`, `SSOExtension`, `url` |
 | `SupportEmail` | String | None | False | Configures the email address shown when the user clicks on the Support Info button |
 | `SupportPhone` | String | None | False | Configures the phone number shown when the user clicks on the Support Info button |
 | `HiddenWidgets` | Array | None | False | Configures which widgets to hide, available widgets are: `DeviceInfo`, `MunkiPendingApps`, `MunkiUpdates`, `IntunePendingApps`, `IntuneUpdates`, `Storage`, `MdmStatus`, `Actions`, `Battery`, `EvergreenInfo` |
 | `HiddenActions` | Array | None | False | Configures which actions to hide, available actions are: `Support`, `ManagedSoftwareCenter`, `ChangePassword`, `Reboot`, `KillAgent`, `SoftwareUpdates`, `GatherLogs` |
-| `NotificationInterval` | String | 4 | False | Configures the interval for notifications in hours for Application Updates and Software Updates notifications |
+| `NotificationInterval` | Integer | 4 | False | Configures the interval for notifications in hours for Application Updates and Software Updates notifications |
 | `NotificationTitle` | String | Support Companion | False | Configures the title for notifications for notifications |
 | `NotificationImage` | String | None | False | Configures an image to add to notifications. Path should be specified |
 | `SoftwareUpdateNotificationMessage` | String | You have software updates available. Take action now! \ud83c\udf89 | False | Configures the message for notifications for Software Updates notifications |


### PR DESCRIPTION
When initiating the app and the `NotificationInterval` was configured, the app crashed because it could not cast NSNumber to an int. This update converts to an int instead of trying to cast.