### PR TITLE
v1.0.5

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -13,164 +10,164 @@ using SupportCompanion.Models;
 using SupportCompanion.Services;
 using SupportCompanion.ViewModels;
 
-namespace SupportCompanion;
-
-public class App : Application
+namespace SupportCompanion
 {
-    public App()
+    public partial class App : Application
     {
-        RegisterAppServices();
-    }
-
-    public static AppConfiguration Config { get; private set; }
-    public IServiceProvider ServiceProvider { get; private set; }
-
-    public override void Initialize()
-    {
-        AvaloniaXamlLoader.Load(this);
-        var prefs = new AppConfigHelper();
-        try
+        public App()
         {
-            prefs.SetPrefs();
-        }
-        catch (Exception e)
-        {
-            var logger = ServiceProvider.GetRequiredService<LoggerService>();
-            logger.Log("App initialization", "Error loading preferences: " + e.Message, 2);
+            RegisterAppServices();
         }
 
-        Config = AppConfigHelper.Config;
-    }
+        public static AppConfiguration Config { get; private set; }
+        public IServiceProvider ServiceProvider { get; private set; }
 
-    private async Task InitializeCultureAsync()
-    {
-        var actionService = ServiceProvider.GetRequiredService<ActionsService>();
-        var mainViewModel = ServiceProvider.GetRequiredService<MainWindowViewModel>();
-
-        try
+        public override void Initialize()
         {
-            // Run the command asynchronously and await the result
-            var locale = await actionService.RunCommandWithOutput("defaults read NSGlobalDomain AppleLocale");
-
-            // Verify and trim the locale string
-            locale = locale?.Trim().Replace("_", "-");
-            // Remove unsupported parts from the locale string
-            if (locale.Contains("@"))
+            AvaloniaXamlLoader.Load(this);
+            var prefs = new AppConfigHelper();
+            try
             {
-                locale = locale.Split('@')[0];
+                prefs.SetPrefs();
             }
-            
-            if (!string.IsNullOrEmpty(locale))
+            catch (Exception e)
             {
-                // Dynamically set the culture based on the macOS locale
-                var cultureInfo = new CultureInfo(locale);
-                Assets.Resources.Culture = cultureInfo;
+                var logger = ServiceProvider.GetRequiredService<LoggerService>();
+                logger.Log("App initialization", "Error loading preferences: " + e.Message, 2);
             }
-            else
-                // Fallback to a default culture if locale is empty
-                Assets.Resources.Culture = CultureInfo.CurrentCulture;
-        }
-        catch (Exception ex)
-        {
-            // Handle exceptions (log them, set a default culture, etc.)
-            Console.WriteLine($"Failed to set culture: {ex.Message}");
-            Assets.Resources.Culture = CultureInfo.CurrentCulture; // or set a default culture
+
+            Config = AppConfigHelper.Config;
         }
 
-        // Update localized strings for menu items
-        mainViewModel.NativeMenuOpenText = Assets.Resources.Open + " Support Companion";
-        mainViewModel.NativeMenuSystemUpdatesText = Assets.Resources.NativeMenuSystemUpdates;
-        mainViewModel.NativeMenuActionsHeader = Assets.Resources.Actions;
-        mainViewModel.NativeMenuQuitAppText = Assets.Resources.Exit;
-    }
-
-    public override async void OnFrameworkInitializationCompleted()
-    {
-        RegisterAppServices();
-        await InitializeCultureAsync(); // Ensure the culture is set before proceeding
-
-        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        private async Task InitializeCultureAsync()
         {
-            DataContext = ServiceProvider.GetRequiredService<MainWindowViewModel>();
-            desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;
-            if (Config.IntuneMode)
-                Config.MunkiMode = false;
-            var updateNotifications = ServiceProvider.GetRequiredService<UpdateNotifications>();
-        }
-
-        DataContext = ServiceProvider.GetRequiredService<MainWindowViewModel>();
-
-        if (Config.Actions != null && Config.Actions.Count > 0)
-        {
+            var actionService = ServiceProvider.GetRequiredService<ActionsService>();
             var mainViewModel = ServiceProvider.GetRequiredService<MainWindowViewModel>();
-            // Create the main "Actions" menu item
-            var actionsMenuItem = new NativeMenuItem { Header = mainViewModel.NativeMenuActionsHeader };
-            actionsMenuItem.Menu = new NativeMenu();
 
-            // Iterate over the Config.Actions and add them as sub-items
-            foreach (var action in Config.Actions)
-                if (action.Value.TryGetValue("Name", out var name) &&
-                    action.Value.TryGetValue("Command", out var command))
+            try
+            {
+                var locale = await actionService.RunCommandWithOutput("defaults read NSGlobalDomain AppleLocale");
+                locale = locale?.Trim().Replace("_", "-");
+                if (locale.Contains("@"))
                 {
-                    var subItem = new NativeMenuItem
-                    {
-                        Header = name,
-                        Command = new RelayCommand(() =>
-                        {
-                            var actionsService = ServiceProvider.GetRequiredService<ActionsService>();
-                            actionsService.RunCommandWithoutOutput(command);
-                        })
-                    };
-                    actionsMenuItem.Menu.Items.Add(subItem);
+                    locale = locale.Split('@')[0];
                 }
 
-            // Insert the main "Actions" menu item at the third position (index 2)
-            var trayIcon = TrayIcon.GetIcons(this).First();
-            if (trayIcon.Menu.Items.Count > 2)
-                trayIcon.Menu.Items.Insert(2, actionsMenuItem);
-            else
-                trayIcon.Menu.Items.Add(actionsMenuItem);
+                if (!string.IsNullOrEmpty(locale))
+                {
+                    var cultureInfo = new CultureInfo(locale);
+                    Assets.Resources.Culture = cultureInfo;
+                }
+                else
+                {
+                    Assets.Resources.Culture = CultureInfo.CurrentCulture;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to set culture: {ex.Message}");
+                Assets.Resources.Culture = CultureInfo.CurrentCulture;
+            }
+
+            mainViewModel.NativeMenuOpenText = Assets.Resources.Open + " Support Companion";
+            mainViewModel.NativeMenuSystemUpdatesText = Assets.Resources.NativeMenuSystemUpdates;
+            mainViewModel.NativeMenuActionsHeader = Assets.Resources.Actions;
+            mainViewModel.NativeMenuQuitAppText = Assets.Resources.Exit;
+        }
+        
+        public override async void OnFrameworkInitializationCompleted()
+        {
+            RegisterAppServices();
+            await InitializeCultureAsync();
+
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;
+
+                DataContext = ServiceProvider.GetRequiredService<MainWindowViewModel>();
+                if (Config.IntuneMode)
+                    Config.MunkiMode = false;
+                var updateNotifications = ServiceProvider.GetRequiredService<UpdateNotifications>();
+
+                // Register the URL handler
+                var urlHandler = new UrlHandler(desktop);
+                NSAppleEventManager.SharedAppleEventManager.SetEventHandler(urlHandler, 
+                    new ObjCRuntime.Selector("handleGetURLEvent:withReplyEvent:"),
+                    AEEventClass.Internet, AEEventID.GetUrl);
+
+                //desktop.MainWindow = new MainWindow { DataContext = DataContext };
+            }
+            
+            if (Config.Actions != null && Config.Actions.Count > 0)
+            {
+                var mainViewModel = ServiceProvider.GetRequiredService<MainWindowViewModel>();
+                // Create the main "Actions" menu item
+                var actionsMenuItem = new NativeMenuItem { Header = mainViewModel.NativeMenuActionsHeader };
+                actionsMenuItem.Menu = new NativeMenu();
+
+                // Iterate over the Config.Actions and add them as sub-items
+                foreach (var action in Config.Actions)
+                    if (action.Value.TryGetValue("Name", out var name) &&
+                        action.Value.TryGetValue("Command", out var command))
+                    {
+                        var subItem = new NativeMenuItem
+                        {
+                            Header = name,
+                            Command = new RelayCommand(() =>
+                            {
+                                var actionsService = ServiceProvider.GetRequiredService<ActionsService>();
+                                actionsService.RunCommandWithoutOutput(command);
+                            })
+                        };
+                        actionsMenuItem.Menu.Items.Add(subItem);
+                    }
+
+                // Insert the main "Actions" menu item at the third position (index 2)
+                var trayIcon = TrayIcon.GetIcons(this).First();
+                if (trayIcon.Menu.Items.Count > 2)
+                    trayIcon.Menu.Items.Insert(2, actionsMenuItem);
+                else
+                    trayIcon.Menu.Items.Add(actionsMenuItem);
+            }
+
+            base.OnFrameworkInitializationCompleted();
         }
 
-        base.OnFrameworkInitializationCompleted();
-    }
+        private void RegisterAppServices()
+        {
+            var serviceCollection = new ServiceCollection();
 
-    private void RegisterAppServices()
-    {
-        var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<IOKitService>();
+            serviceCollection.AddSingleton<SystemInfoService>();
+            serviceCollection.AddSingleton<MunkiAppsService>();
+            serviceCollection.AddSingleton<StorageService>();
+            serviceCollection.AddSingleton<MdmStatusService>();
+            serviceCollection.AddSingleton<CatalogsService>();
+            serviceCollection.AddSingleton<ActionsService>();
+            serviceCollection.AddSingleton<ClipboardService>();
+            serviceCollection.AddSingleton<NotificationService>();
+            serviceCollection.AddSingleton<IntuneAppsService>();
+            serviceCollection.AddSingleton<MacPasswordService>();
+            serviceCollection.AddSingleton<UpdateNotifications>();
+            serviceCollection.AddSingleton<LoggerService>();
 
-        // Register your services
-        serviceCollection.AddSingleton<IOKitService>();
-        serviceCollection.AddSingleton<SystemInfoService>();
-        serviceCollection.AddSingleton<MunkiAppsService>();
-        serviceCollection.AddSingleton<StorageService>();
-        serviceCollection.AddSingleton<MdmStatusService>();
-        serviceCollection.AddSingleton<CatalogsService>();
-        serviceCollection.AddSingleton<ActionsService>();
-        serviceCollection.AddSingleton<ClipboardService>();
-        serviceCollection.AddSingleton<NotificationService>();
-        serviceCollection.AddSingleton<IntuneAppsService>();
-        serviceCollection.AddSingleton<MacPasswordService>();
-        serviceCollection.AddSingleton<UpdateNotifications>();
-        serviceCollection.AddSingleton<LoggerService>();
+            serviceCollection.AddSingleton<DeviceWidgetViewModel>();
+            serviceCollection.AddSingleton<MunkiPendingAppsViewModel>();
+            serviceCollection.AddSingleton<MunkiUpdatesViewModel>();
+            serviceCollection.AddSingleton<StorageViewModel>();
+            serviceCollection.AddSingleton<MdmStatusViewModel>();
+            serviceCollection.AddSingleton<EvergreenWidgetViewModel>();
+            serviceCollection.AddSingleton<ActionsViewModel>();
+            serviceCollection.AddSingleton<BatteryWidgetViewModel>();
+            serviceCollection.AddSingleton<ApplicationsViewModel>();
+            serviceCollection.AddSingleton<MainWindowViewModel>();
+            serviceCollection.AddSingleton<SupportDialogViewModel>();
+            serviceCollection.AddSingleton<IntuneUpdatesViewModel>();
+            serviceCollection.AddSingleton<IntunePendingAppsViewModel>();
+            serviceCollection.AddSingleton<UserViewModel>();
+            serviceCollection.AddSingleton<MacPasswordViewModel>();
 
-        // Register view models
-        serviceCollection.AddSingleton<DeviceWidgetViewModel>();
-        serviceCollection.AddSingleton<MunkiPendingAppsViewModel>();
-        serviceCollection.AddSingleton<MunkiUpdatesViewModel>();
-        serviceCollection.AddSingleton<StorageViewModel>();
-        serviceCollection.AddSingleton<MdmStatusViewModel>();
-        serviceCollection.AddSingleton<EvergreenWidgetViewModel>();
-        serviceCollection.AddSingleton<ActionsViewModel>();
-        serviceCollection.AddSingleton<BatteryWidgetViewModel>();
-        serviceCollection.AddSingleton<ApplicationsViewModel>();
-        serviceCollection.AddSingleton<MainWindowViewModel>();
-        serviceCollection.AddSingleton<SupportDialogViewModel>();
-        serviceCollection.AddSingleton<IntuneUpdatesViewModel>();
-        serviceCollection.AddSingleton<IntunePendingAppsViewModel>();
-        serviceCollection.AddSingleton<UserViewModel>();
-        serviceCollection.AddSingleton<MacPasswordViewModel>();
-
-        ServiceProvider = serviceCollection.BuildServiceProvider();
+            ServiceProvider = serviceCollection.BuildServiceProvider();
+        }
     }
 }

--- a/Assets/Resources.nb-no.resx
+++ b/Assets/Resources.nb-no.resx
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<root>
+    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <xsd:element name="root" msdata:IsDataSet="true">
+            
+        </xsd:element>
+    </xsd:schema>
+    <resheader name="resmimetype">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name="version">
+        <value>1.3</value>
+    </resheader>
+    <resheader name="reader">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <resheader name="writer">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <data name="Actions" xml:space="preserve">
+        <value>Operasjoner</value>
+    </data>
+    <data name="ActionsChangePassword" xml:space="preserve">
+        <value>Bytt passord</value>
+    </data>
+    <data name="ActionsGatherLogs" xml:space="preserve">
+        <value>Samle loggfiler</value>
+    </data>
+    <data name="ActionsGetSupport" xml:space="preserve">
+        <value>Støtte</value>
+    </data>
+    <data name="ActionsOpenMSC" xml:space="preserve">
+        <value>Åpne MSC</value>
+    </data>
+    <data name="ActionsReboot" xml:space="preserve">
+        <value>Omstart</value>
+    </data>
+    <data name="ActionsRestartIntuneAgent" xml:space="preserve">
+        <value>Restarte Intune-agenten</value>
+    </data>
+    <data name="ActionsSoftwareUpdates" xml:space="preserve">
+        <value>Oppdateringer</value>
+    </data>
+    <data name="ActionsSupportInfo" xml:space="preserve">
+        <value>Støtteinfo</value>
+    </data>
+    <data name="ApplicationInstallProgress" xml:space="preserve">
+        <value>Installasjonsstatus for programmer</value>
+    </data>
+    <data name="Battery" xml:space="preserve">
+        <value>Batteri</value>
+    </data>
+    <data name="BatteryCycleCount" xml:space="preserve">
+        <value>Sykluser</value>
+    </data>
+    <data name="BatteryHealth" xml:space="preserve">
+        <value>Helse</value>
+    </data>
+    <data name="Close" xml:space="preserve">
+        <value>Lukk</value>
+    </data>
+    <data name="Days" xml:space="preserve">
+        <value>dager</value>
+    </data>
+    <data name="DaysAgo" xml:space="preserve">
+        <value>Dager siden</value>
+    </data>
+    <data name="DeviceInfo" xml:space="preserve">
+        <value>Enhetsinformasjon</value>
+    </data>
+    <data name="DeviceInfoHostName" xml:space="preserve">
+        <value>Navn</value>
+    </data>
+    <data name="DeviceInfoIP" xml:space="preserve">
+        <value>IP-addresse</value>
+    </data>
+    <data name="DeviceInfoLastReboot" xml:space="preserve">
+        <value>Sist omstart</value>
+    </data>
+    <data name="DeviceInfoLastRebootToolTip" xml:space="preserve">
+        <value>Å restarte maskinen jevnlig kan forbedre ytelse og levetid&amp;#10;ved å slette midlertidige filer og frigjøre systemressurser.</value>
+    </data>
+    <data name="DeviceInfoMemory" xml:space="preserve">
+        <value>Minne</value>
+    </data>
+    <data name="DeviceInfoModel" xml:space="preserve">
+        <value>Modell</value>
+    </data>
+    <data name="DeviceInfoOSBuild" xml:space="preserve">
+        <value>OS-build</value>
+    </data>
+    <data name="DeviceInfoOSVersion" xml:space="preserve">
+        <value>OS-versjon</value>
+    </data>
+    <data name="DeviceInfoProcessor" xml:space="preserve">
+        <value>Prosessor</value>
+    </data>
+    <data name="DeviceInfoSerialNumber" xml:space="preserve">
+        <value>Serielnummer</value>
+    </data>
+    <data name="DeviceManagement" xml:space="preserve">
+        <value>Enhetshåndtering</value>
+    </data>
+    <data name="DeviceManagementEnrolled" xml:space="preserve">
+        <value>Registrert</value>
+    </data>
+    <data name="DeviceManagementEnrollmentDate" xml:space="preserve">
+        <value>Registreringsdato</value>
+    </data>
+    <data name="EvergreenCatalogs" xml:space="preserve">
+        <value>Kataloger</value>
+    </data>
+    <data name="Exit" xml:space="preserve">
+        <value>Avslutt</value>
+    </data>
+    <data name="InstalledApps" xml:space="preserve">
+        <value>Installerte applikasjoner</value>
+    </data>
+    <data name="InstalledAppsManage" xml:space="preserve">
+        <value>Håndtere</value>
+    </data>
+    <data name="KerberosSSOADPasswordExpiry" xml:space="preserve">
+        <value>Utløp av AD-passord</value>
+    </data>
+    <data name="KerberosSSOADUsername" xml:space="preserve">
+        <value>AD-brukernavn</value>
+    </data>
+    <data name="KerberosSSOLastADPasswordChange" xml:space="preserve">
+        <value>Siste AD-passordbytte</value>
+    </data>
+    <data name="KerberosSSOLastLocalPasswordChange" xml:space="preserve">
+        <value>Siste lokale passordbytte</value>
+    </data>
+    <data name="KerberosSSORealm" xml:space="preserve">
+        <value>Domene</value>
+    </data>
+    <data name="MenuApplications" xml:space="preserve">
+        <value>Applikasjoner</value>
+    </data>
+    <data name="MenuHome" xml:space="preserve">
+        <value>Hjem</value>
+    </data>
+    <data name="MenuIdentity" xml:space="preserve">
+        <value>Identitet</value>
+    </data>
+    <data name="Name" xml:space="preserve">
+        <value>Navn</value>
+    </data>
+    <data name="NativeMenuSystemUpdates" xml:space="preserve">
+        <value>Systemoppdateringer</value>
+    </data>
+    <data name="Open" xml:space="preserve">
+        <value>Åpne</value>
+    </data>
+    <data name="PendingUpdates" xml:space="preserve">
+        <value>Ventende oppdateringer</value>
+    </data>
+    <data name="PendingUpdatesOpenCompanyPortal" xml:space="preserve">
+        <value>Åpne Firmaportal</value>
+    </data>
+    <data name="PendingUpdatesOpenMSC" xml:space="preserve">
+        <value>Åpne MSC-oppdateringer</value>
+    </data>
+    <data name="PlatformSSOExtensionIdentifier" xml:space="preserve">
+        <value>Utvidelsesidentifikator</value>
+    </data>
+    <data name="PlatformSSOLoginFrequency" xml:space="preserve">
+        <value>Innloggingsfrekvens</value>
+    </data>
+    <data name="PlatformSSOLoginType" xml:space="preserve">
+        <value>Innloggingstype</value>
+    </data>
+    <data name="PlatformSSONewUserAuthorizationMode" xml:space="preserve">
+        <value>Ny brukerautentiseringsmetode</value>
+    </data>
+    <data name="PlatformSSORegistrationCompleted" xml:space="preserve">
+        <value>Registrering ferdig</value>
+    </data>
+    <data name="PlatformSSOSDKVersion" xml:space="preserve">
+        <value>SDK-versjon</value>
+    </data>
+    <data name="PlatformSSOSharedDeviceKeys" xml:space="preserve">
+        <value>Delte enhetsnøkler</value>
+    </data>
+    <data name="PlatformSSOUserAuthorizationMode" xml:space="preserve">
+        <value>Brukertilgangsmetode</value>
+    </data>
+    <data name="Storage" xml:space="preserve">
+        <value>Lagring</value>
+    </data>
+    <data name="StorageName" xml:space="preserve">
+        <value>Navn</value>
+    </data>
+    <data name="StorageUsage" xml:space="preserve">
+        <value>Brukt</value>
+    </data>
+    <data name="SupportDialogEmail" xml:space="preserve">
+        <value>E-post</value>
+    </data>
+    <data name="SupportDialogPhone" xml:space="preserve">
+        <value>Telefon</value>
+    </data>
+    <data name="UserInformation" xml:space="preserve">
+        <value>Brukerinformasjon</value>
+    </data>
+    <data name="UserInformationHomeDirectory" xml:space="preserve">
+        <value>Hjemmekatalog</value>
+    </data>
+    <data name="UserInformationLogin" xml:space="preserve">
+        <value>Identifikator</value>
+    </data>
+    <data name="UserInformationUsername" xml:space="preserve">
+        <value>Brukernavn</value>
+    </data>
+</root>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <key>ShowMenuToggle</key>
 <false/>
 ```
+### Fixed
+- The `BrandName` was always displayed in white text in the side menu, which made it hard to read if light mode was enabled. Text color property has been removed to ensure it is set dynamically based on the user's system preferences
 
 ## [1.0.4] - 2024-05-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] -
+### Added
+- Added a new configuration to disable the menu toggle button in the app. This allows for admins to disable the menu toggle button if they want to prevent users from hiding the menu. Example configuration:
+```xml
+<key>ShowMenuToggle</key>
+<false/>
+```
+
 ## [1.0.4] - 2024-05-31
 ### Added
 - Localized the app to `Swedish` and `French`. The app will now display in the user's preferred language if it is set to one of these languages in macOS. If the user's preferred language is not one of these, the app will default to English. Thank you, @hachirotahoshino, for the French localization https://github.com/macadmins/SupportCompanion/issues/31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.5] -
+## [1.0.5] - 2024-06-10
 ### Added
-- Added a new configuration to disable the menu toggle button in the app. This allows for admins to disable the menu toggle button if they want to prevent users from hiding the menu. Example configuration:
+- Added a new configuration to disable the menu toggle button in the app. This allows for admins to disable the menu toggle button if they want to prevent users from hiding the menu. Example configuration: https://github.com/macadmins/SupportCompanion/issues/38
 ```xml
 <key>ShowMenuToggle</key>
 <false/>
 ```
+- Option to start the app using a URL scheme. This allows for admins to start the app using a URL scheme, which can be useful for starting the app from a script or another app. The URL scheme is `supportcompanion://home`. When started using the URL scheme, the app will exit when the window is closed instead of running in the background https://github.com/macadmins/SupportCompanion/issues/36
+- Option to provide the `BrandLogo` as a base64 string in the configuration. This allows for admins to provide the `BrandLogo` as a base64 string in the configuration instead of a local path. This can be useful for providing the logo as part of a configuration profile. Example configuration:
+```xml
+<key>BrandLogo</key>
+<string>{BASE64 STRING}</string>
+```
+- Norwegian localization, thanks @johnhans for the Norwegian localization
+### Changed
+- Margins around `BrandLogo` has been increased to make it look better in the side menu
 ### Fixed
-- The `BrandName` was always displayed in white text in the side menu, which made it hard to read if light mode was enabled. Text color property has been removed to ensure it is set dynamically based on the user's system preferences
+- The `BrandName` was always displayed in white text in the side menu, which made it hard to read if light mode was enabled. Text color property has been removed to ensure it is set dynamically based on the user's system preferences https://github.com/macadmins/SupportCompanion/issues/39
 
 ## [1.0.4] - 2024-05-31
 ### Added

--- a/Helpers/AppConfigHelper.cs
+++ b/Helpers/AppConfigHelper.cs
@@ -141,6 +141,9 @@ public class AppConfigHelper
                 case "IntuneMode":
                     Config.IntuneMode = (bool)pref.Value;
                     break;
+                case "ShowMenuToggle":
+                    Config.ShowMenuToggle = (bool)pref.Value;
+                    break;
             }
 
         if (!string.IsNullOrEmpty(Config.BrandColor))

--- a/Helpers/UrlHandler.cs
+++ b/Helpers/UrlHandler.cs
@@ -1,0 +1,55 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using SupportCompanion.ViewModels;
+using SupportCompanion.Views;
+
+namespace SupportCompanion
+{
+    public class UrlHandler : NSObject
+    {
+        private readonly IClassicDesktopStyleApplicationLifetime _desktop;
+        public static bool ActivatedViaUrl { get; private set; }
+
+        public UrlHandler(IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            _desktop = desktop;
+        }
+        
+        [Export("handleGetURLEvent:withReplyEvent:")]
+        public void HandleGetURLEvent(NSAppleEventDescriptor descriptor, NSAppleEventDescriptor replyEvent)
+        {
+            var paramDescriptor = descriptor.ParamDescriptorForKeyword(AEKeywordDirectObject);
+            if (paramDescriptor != null)
+            {
+                var url = paramDescriptor.StringValue;
+                if (url != null)
+                {
+                    Dispatcher.UIThread.Post(() => HandleUri(url));
+                }
+            }
+        }
+
+        private void HandleUri(string uri)
+        {
+            if (uri == "supportcompanion://home")
+            {
+                if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopApp)
+                {
+                    
+                    ActivatedViaUrl = true;
+                    desktopApp.ShutdownMode = ShutdownMode.OnMainWindowClose;
+                    var mainWindowViewModel =
+                        ((App)Application.Current).ServiceProvider.GetRequiredService<MainWindowViewModel>();
+                    desktopApp.MainWindow = new MainWindow { DataContext = mainWindowViewModel };
+                    desktopApp.MainWindow.Show();
+                }
+            }
+        }
+
+        // Define the AEKeywordDirectObject manually
+        private const uint AEKeywordDirectObject = 0x2D2D2D2D;
+    }
+}

--- a/Info.plist
+++ b/Info.plist
@@ -1,30 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>CFBundleIconFile</key>
-        <string>appicon</string>
-        <key>CFBundleIconName</key>
-        <string>appicon</string>
-        <key>CFBundleIdentifier</key>
-        <string>com.almenscorner.supportcompanion</string>
-        <key>CFBundleName</key>
-        <string>SupportCompanion</string>
-        <key>CFBundleVersion</key>
-        <string>1.0.4</string>
-        <key>LSMinimumSystemVersion</key>
-        <string>10.15</string>
-        <key>CFBundleExecutable</key>
-        <string>SupportCompanion</string>
-        <key>CFBundleInfoDictionaryVersion</key>
-        <string>6.0</string>
-        <key>CFBundlePackageType</key>
-        <string>APPL</string>
-        <key>CFBundleShortVersionString</key>
-        <string>1.0.4</string>
-        <key>NSHighResolutionCapable</key>
-        <true/>
-        <key>LSUIElement</key>
-        <string>1</string>
-    </dict>
+<dict>
+	<key>CFBundleIconFile</key>
+	<string>appicon</string>
+	<key>CFBundleIconName</key>
+	<string>appicon</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.almenscorner.supportcompanion</string>
+	<key>CFBundleName</key>
+	<string>SupportCompanion</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.almenscorner.supportcompanion</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>supportcompanion</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1.0.5</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.15</string>
+	<key>CFBundleExecutable</key>
+	<string>SupportCompanion</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.5</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>LSUIElement</key>
+	<string>1</string>
+</dict>
 </plist>

--- a/Models/AppConfiguration.cs
+++ b/Models/AppConfiguration.cs
@@ -10,7 +10,7 @@ public class AppConfiguration
         "ChangePasswordMode", "SupportEmail", "SupportPhone", "HiddenActions", "NotificationInterval",
         "NotificationTitle", "NotificationImage", "SoftwareUpdateNotificationMessage",
         "SoftwareUpdateNotificationButtonText", "AppUpdateNotificationMessage", "AppUpdateNotificationButtonText",
-        "MunkiMode", "IntuneMode", "LogFolders", "Actions", "BrandLogo"
+        "MunkiMode", "IntuneMode", "LogFolders", "Actions", "BrandLogo", "ShowMenuToggle"
     };
 
     public string BrandName { get; set; } = string.Empty;
@@ -41,4 +41,5 @@ public class AppConfiguration
     public bool MunkiMode { get; set; } = true;
     public bool IntuneMode { get; set; }
     public Dictionary<string, Dictionary<string, string>> Actions { get; set; } = new();
+    public bool ShowMenuToggle { get; set; } = true;
 }

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Many aspects of the app can be configured using MDM profiles, the folloing keys 
 | `IntuneMode` | Bool | False | False | Configures the app to use Intune for application information. Only supports PKG and DMG type apps, not LOB. |
 | `LogFolders` | Array | /Library/Logs/Microsoft | False | Configures the log folders to gather logs from. Only used when gathering logs. |
 | `Actions` | Array | None | False | Configures custom actions to add to the tray menu. See example below. |
-| `ShowMenuToggle` | Bool | True | False | Configures whether to show the menu toggle button in the app. |
+| `ShowMenuToggle` | Bool | True | False | Configures whether to show the menu toggle button in the apps side menu. |
 
 ### Example Configuration
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Many aspects of the app can be configured using MDM profiles, the folloing keys 
 | `IntuneMode` | Bool | False | False | Configures the app to use Intune for application information. Only supports PKG and DMG type apps, not LOB. |
 | `LogFolders` | Array | /Library/Logs/Microsoft | False | Configures the log folders to gather logs from. Only used when gathering logs. |
 | `Actions` | Array | None | False | Configures custom actions to add to the tray menu. See example below. |
+| `ShowMenuToggle` | Bool | True | False | Configures whether to show the menu toggle button in the app. |
 
 ### Example Configuration
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Many aspects of the app can be configured using MDM profiles, the folloing keys 
 | --- | --- | --- | --- | --- |
 | `BrandName` | String | None | False | Configures the brand name shown in the menu |
 | `BrandColor` | String | Blue | False | Configures the brand color shown in the app, available colors are: Blue, Green, Red, Orange |
-| `BrandLogo` | String | None | False | Configures the brand logo shown in the apps side menu. Specify a local path |
+| `BrandLogo` | String | None | False | Configures the brand logo shown in the apps side menu. Specify a local path or base64 string |
 | `SupportPageUrl` | String | None | False | Configures the URL to open when the user clicks on the Get Support button |
 | `ChangePasswordUrl` | String | None | False | Configures the URL to open when the user clicks on the Change Password button |
 | `ChangePasswordMode` | String | local | False | Configures the mode for the Change Password button, available modes are: `local`, `SSOExtension`, `url` |

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -29,6 +29,7 @@ public partial class MainWindowViewModel : ObservableObject
         {
             BrandLogo = new Bitmap(App.Config.BrandLogo);
             ShowLogo = true;
+            ShowMenuToggle = App.Config.ShowMenuToggle;
         }
 
         _actionsService = actionsService;
@@ -38,6 +39,7 @@ public partial class MainWindowViewModel : ObservableObject
     public bool ShowLogo { get; private set; }
     public string BrandName { get; private set; }
     public Bitmap BrandLogo { get; private set; }
+    public bool ShowMenuToggle { get; private set; }
 
     [RelayCommand]
     private void ToggleBaseTheme()

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -25,6 +25,11 @@
              to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
         <vm:MainWindowViewModel />
     </Design.DataContext>
+    <controls:SukiWindow.Styles>
+        <Style Selector="Button#PART_SidebarToggleButton">
+            <Setter Property="IsVisible" Value="{Binding ShowMenuToggle}"/>
+        </Style>
+    </controls:SukiWindow.Styles>
     <controls:SukiSideMenu>
         <controls:SukiSideMenu.HeaderContent>
             <StackPanel>

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -41,7 +41,6 @@
                 <TextBlock Text="{Binding BrandName}"
                            FontSize="20"
                            FontWeight="Bold"
-                           Foreground="White"
                            VerticalAlignment="Center"
                            HorizontalAlignment="Center"
                            Margin="0,0,0,10"

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -12,9 +12,8 @@
                      x:DataType="vm:MainWindowViewModel"
                      x:CompileBindings="True"
                      Title=""
-                     Width="1250" Height="765"
                      MinWidth="1300" MaxWidth="1300"
-                     MinHeight="765" MaxHeight="765"
+                     MinHeight="765" MaxHeight="800"
                      controls:SukiHost.ToastLocation="BottomRight"
                      controls:SukiHost.ToastLimit="4"
                      ExtendClientAreaToDecorationsHint="False"
@@ -34,7 +33,7 @@
         <controls:SukiSideMenu.HeaderContent>
             <StackPanel>
                 <Image Source="{Binding BrandLogo}"
-                       Margin="20"
+                       Margin="40"
                        MaxHeight="200"
                        MaxWidth="200"
                        IsVisible="{Binding ShowLogo}" />

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -37,9 +37,12 @@ public partial class MainWindow : SukiWindow
 
     private void OnClosing(object sender, CancelEventArgs e)
     {
-        e.Cancel = true; // Cancel the close event
-        Hide(); // Hide the window instead
-        NotifyViewModelsWindowHidden(); // Notify view models that the window is hidden
+        if (!UrlHandler.ActivatedViaUrl)
+        {
+            e.Cancel = true; // Cancel the close event
+            Hide(); // Hide the window instead
+            NotifyViewModelsWindowHidden(); // Notify view models that the window is hidden
+        }
     }
 
     private void OnIsVisibleChanged(bool isVisible)


### PR DESCRIPTION
### Added
- Added a new configuration to disable the menu toggle button in the app. This allows for admins to disable the menu toggle button if they want to prevent users from hiding the menu. Example configuration: 
```xml
<key>ShowMenuToggle</key>
<false/>
```
- Option to start the app using a URL scheme. This allows for admins to start the app using a URL scheme, which can be useful for starting the app from a script or another app. The URL scheme is `supportcompanion://home`. When started using the URL scheme, the app will exit when the window is closed instead of running in the background 
- Option to provide the `BrandLogo` as a base64 string in the configuration. This allows for admins to provide the `BrandLogo` as a base64 string in the configuration instead of a local path. This can be useful for providing the logo as part of a configuration profile. Example configuration:
```xml
<key>BrandLogo</key>
<string>{BASE64 STRING}</string>
```
- Norwegian localization, thanks @johnhans for the Norwegian localization
### Changed
- Margins around `BrandLogo` has been increased to make it look better in the side menu
### Fixed
- The `BrandName` was always displayed in white text in the side menu, which made it hard to read if light mode was enabled. Text color property has been removed to ensure it is set dynamically based on the user's system preferences 

closes #39 
closes #38 
closes #36  