### PR TITLE
App crash when no BrandLogo is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2024-06-17
+### Fixed
+- Not configuring the `BrandLogo` in the configuration would cause the app to crash on startup. This has been fixed by adding a check to see if the `BrandLogo` is configured before trying to load it
+
 ## [1.0.5] - 2024-06-10
 ### Added
 - Added a new configuration to disable the menu toggle button in the app. This allows for admins to disable the menu toggle button if they want to prevent users from hiding the menu. Example configuration: https://github.com/macadmins/SupportCompanion/issues/38

--- a/Info.plist
+++ b/Info.plist
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.0.5</string>
+	<string>1.0.6</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.15</string>
 	<key>CFBundleExecutable</key>
@@ -32,7 +32,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.5</string>
+	<string>1.0.6</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>LSUIElement</key>


### PR DESCRIPTION
### Fixed
- Not configuring the `BrandLogo` in the configuration would cause the app to crash on startup. This has been fixed by adding a check to see if the `BrandLogo` is configured before trying to load it