### PR TITLE
Add check for root and use Apple best practice

### DIFF
--- a/Assets/Uninstall.sh
+++ b/Assets/Uninstall.sh
@@ -1,5 +1,12 @@
-current_user=$(ls -l /dev/console | awk '{print $3}')
-console_user_uid=$(/usr/bin/id -u "$current_user")
+#!/bin/sh
+# Script requires root so check for root access
+if [ $(id -u) -ne 0 ]; then
+    echo "Please run this script as root or using sudo"
+    exit 1
+fi
+# Use Apple Recommended Method to detect the user signed in to the desktop
+current_user=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ && ! /loginwindow/ { print $3 }')
+console_user_uid=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/UID :/ && ! /loginwindow/ { print $3 }' )
 # Kill the process
 echo "Killing the process..."
 pkill -f SupportCompanion

--- a/Assets/Uninstall.sh
+++ b/Assets/Uninstall.sh
@@ -6,7 +6,7 @@ if [ $(id -u) -ne 0 ]; then
 fi
 # Use Apple Recommended Method to detect the user signed in to the desktop
 current_user=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ && ! /loginwindow/ { print $3 }')
-console_user_uid=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/UID :/ && ! /loginwindow/ { print $3 }' )
+console_user_uid=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/kCGSSessionUserIDKey/ {print $NF; exit}' )
 # Kill the process
 echo "Killing the process..."
 pkill -f SupportCompanion


### PR DESCRIPTION
The current version of the uninstall script:
1. Doesn't contain an interpreter directive
2. Requires root but doesn't check that it's running as root.
3. Uses a method that is not recommended by Apple for detecting current desktop user.

This PR:
1. sets the directive to be `#!/bin/sh` to ensure the most compatibility across macOS versions/environments.
2. Checks that the script is being run as `root` or via `sudo`
3. Switches to using the POSIX shell compliant version of scutil parsing as documented by scriptingosx in https://scriptingosx.com/2020/02/getting-the-current-user-in-macos-update/
