### PR TITLE
v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2024-12-06
+### Changed
+- Added a softer shade of orange and red when light mode is enabled to improve visibility and readability.
+
+### Added
+- Option to hide Categories and Dividers on the Desktop Info view. This allows for a cleaner and more focused view of the information displayed. Example configuration:
+```xml
+<key>DesktopInfoHideItems</key>
+<array>
+    <string>Category</string>
+    <string>Divider</string>
+</array>
+```
+
 ## [2.0.1] - 2024-12-05
 ### Changed
 - Added a preinstall script that will uninstall version 1.X if found.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.2] - 2024-12-06
 ### Changed
 - Added a softer shade of orange and red when light mode is enabled to improve visibility and readability.
+- If launching the app using a URL scheme, the app will now exit **only** when `supportcompanion://` is used. This allows for the app to be started using a URL scheme and remain open when using `supportcompanion://home` or similar. Example:
+
+Will exit when the window is closed:
+```bash
+open supportcompanion://
+```
+
+Will remain open when the window is closed:
+```bash
+open supportcompanion://home
+```
 
 ### Added
 - Option to hide Categories and Dividers on the Desktop Info view. This allows for a cleaner and more focused view of the information displayed. Example configuration:

--- a/SupportCompanion/AppDelegate.swift
+++ b/SupportCompanion/AppDelegate.swift
@@ -18,6 +18,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let appStateManager = AppStateManager.shared
     var mainWindow: NSWindow?
     static var urlLaunch = false
+    static var shouldExit = false
     private var notificationDelegate: NotificationDelegate?
     private var cancellables: Set<AnyCancellable> = []
     @AppStorage("isDarkMode") private var isDarkMode: Bool = false
@@ -25,6 +26,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func application(_ application: NSApplication, open urls: [URL]) {
         guard let url = urls.first else { return }
+        switch url.host?.lowercased() {
+            case nil:
+                AppDelegate.shouldExit = true
+            default:
+                AppDelegate.shouldExit = false
+        }
         AppDelegate.urlLaunch = true
         showWindow()
         NotificationCenter.default.post(name: .handleIncomingURL, object: url)

--- a/SupportCompanion/ContentView.swift
+++ b/SupportCompanion/ContentView.swift
@@ -145,7 +145,7 @@ struct ContentView: View {
         case "knowledgebase":
             selectedItem = items.first(where: { $0.id == Constants.Navigation.knowledgeBase })
         default:
-            Logger.shared.logDebug("Unhandled URL: \(url)")
+            selectedItem = items.first(where: { $0.id == Constants.Navigation.home })
         }
     }
     

--- a/SupportCompanion/Extensions/Extensions.swift
+++ b/SupportCompanion/Extensions/Extensions.swift
@@ -71,7 +71,7 @@ extension ToastConfig {
 
 extension AppDelegate: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
-        if AppDelegate.urlLaunch {
+        if AppDelegate.shouldExit {
             NSApplication.shared.terminate(nil)
         }
         Logger.shared.logDebug("Main window is closing.")

--- a/SupportCompanion/Extensions/Extensions.swift
+++ b/SupportCompanion/Extensions/Extensions.swift
@@ -88,3 +88,11 @@ extension AppDelegate: NSWindowDelegate {
 extension Notification.Name {
     static let handleIncomingURL = Notification.Name("handleIncomingURL")
 }
+
+extension Color {
+    // Orange shades
+    static let orangeLight = Color(hue: 0.1, saturation: 0.9, brightness: 0.75) // Softer orange for light mode
+    
+    // Red shades
+    static let redLight = Color(hue: 0.02, saturation: 0.8, brightness: 0.7) // Softer red for light mode
+}

--- a/SupportCompanion/Info.plist
+++ b/SupportCompanion/Info.plist
@@ -19,9 +19,9 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.0.2</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.1</string>
+	<string>2.0.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/SupportCompanion/Models/Storage.swift
+++ b/SupportCompanion/Models/Storage.swift
@@ -14,16 +14,6 @@ struct StorageInfo: Identifiable {
     let fileVault: Bool
     let usage: Double
     
-    var percentageColor: Color {
-        if usage > 80 {
-            return Color(NSColor.red)
-        } else if usage > 60 {
-            return Color(NSColor.orange)
-        } else {
-            return Color(NSColor.green)
-        }
-    }
-    
     func toKeyValuePairs() -> [(key: String, display: String, value: InfoValue)] {
         return [
             (

--- a/SupportCompanion/ViewModels/StorageInfoManager.swift
+++ b/SupportCompanion/ViewModels/StorageInfoManager.swift
@@ -10,6 +10,8 @@ import Combine
 import SwiftUI
 
 class StorageInfoManager: ObservableObject {
+    @Environment(\.colorScheme) var colorScheme
+    
     static let shared = StorageInfoManager(
         storageInfo: StorageInfo(
             id: UUID(),
@@ -36,6 +38,16 @@ class StorageInfoManager: ObservableObject {
     
     func refresh() {
         self.updateStorageInfo()
+    }
+    
+    func getPercentageColor(percentage: Double) -> Color {
+        if percentage < 50 {
+            return .green
+        } else if percentage < 80 {
+            return colorScheme == .light ? .orangeLight : .orange
+        } else {
+            return colorScheme == .light ? .redLight : .red
+        }
     }
     
     func updateStorageInfo(usagePercentage: Double = getStorageUsagePercentage()) {

--- a/SupportCompanion/Views/Cards/DeviceInformationCard.swift
+++ b/SupportCompanion/Views/Cards/DeviceInformationCard.swift
@@ -11,9 +11,12 @@ import SwiftUI
 struct DeviceInformationCard: View {
     @ObservedObject var viewModel: CardGridViewModel
     @EnvironmentObject var appState: AppStateManager
+    @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
         if viewModel.isCardVisible("DeviceInformation") {
+            let groupedData = groupedDeviceInfoArray() // Precomputed grouped data
+
             CustomCard(
                 title: "\(Constants.CardTitle.deviceInfo)",
                 titleImageName: "laptopcomputer",
@@ -22,26 +25,13 @@ struct DeviceInformationCard: View {
                 buttonHelpText: Constants.ToolTips.deviceInfoCopy,
                 content: {
                     VStack(alignment: .leading, spacing: 10) {
-                        ForEach(Array(groupedDeviceInfoArray().enumerated()), id: \.1.0) { index, group in
-                            SectionHeader(title: group.0) // Category (e.g., Hardware Specifications)
-                            VStack(alignment: .leading, spacing: 5) {
-                                ForEach(group.1, id: \.key) { item in
-                                    if item.key == Constants.DeviceInfo.Keys.lastRestart {
-                                        LastRestartRow(
-                                            label: item.display,
-                                            value: item.value.rawValue as? Int ?? 0
-                                        )
-                                    } else {
-                                        DeviceInfoRow(label: item.display, value: item.value.displayValue)
-                                    }
-                                }
-                            }
-
-                            // Add a divider only if it's not the last group
-                            if index < groupedDeviceInfoArray().count - 1 {
-                                Divider()
-                                    .background(Color.white.opacity(0.2))
-                            }
+                        ForEach(Array(groupedData.enumerated()), id: \.1.0) { index, group in
+                            DeviceInfoSection(
+                                index: index,
+                                group: group,
+                                totalGroups: groupedData.count,
+                                colorScheme: colorScheme // Pass colorScheme explicitly
+                            )
                         }
                     }
                     .padding(.horizontal)
@@ -73,10 +63,42 @@ struct DeviceInformationCard: View {
     }
 }
 
+struct DeviceInfoSection: View {
+    let index: Int
+    let group: (String, [(key: String, display: String, value: InfoValue)])
+    let totalGroups: Int
+    let colorScheme: ColorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            SectionHeader(title: group.0) // Category (e.g., Hardware Specifications)
+
+            VStack(alignment: .leading, spacing: 5) {
+                ForEach(group.1, id: \.key) { item in
+                    if item.key == Constants.DeviceInfo.Keys.lastRestart {
+                        LastRestartRow(
+                            label: item.display,
+                            value: item.value.rawValue as? Int ?? 0,
+                            colorScheme: colorScheme // Pass colorScheme explicitly
+                        )
+                    } else {
+                        DeviceInfoRow(label: item.display, value: item.value.displayValue)
+                    }
+                }
+            }
+
+            // Add a divider only if it's not the last group
+            if index < totalGroups - 1 {
+                Divider()
+                    .background(Color.white.opacity(0.2))
+            }
+        }
+    }
+}
+
 struct SectionHeader: View {
     let title: String
 
-    // Computed property for the image name
     private var image: String {
         switch title {
         case Constants.DeviceInfo.Categories.hardwareSpecs:
@@ -103,18 +125,17 @@ struct SectionHeader: View {
 struct DeviceInfoRow: View {
     let label: String
     let value: String?
+    
     var body: some View {
         HStack {
             Text(label)
                 .font(.system(size: 14))
                 .bold()
-                //.frame(width: 150, alignment: .leading) // Set fixed width for labels
+                .frame(width: 150, alignment: .leading) // Set fixed width for labels
 
             Spacer()
             Text(value ?? "N/A")
                 .font(.system(size: 14))
-                //.multilineTextAlignment(.trailing) // Ensure values align properly
-
         }
     }
 }
@@ -122,8 +143,12 @@ struct DeviceInfoRow: View {
 struct LastRestartRow: View {
     let label: String
     let value: Int // Days since last restart
+    let colorScheme: ColorScheme
 
     var body: some View {
+        let color = colorForLastRestart(value: value)
+        let isGreen = color == .green
+
         HStack {
             Text(label)
                 .font(.system(size: 14))
@@ -133,24 +158,25 @@ struct LastRestartRow: View {
             Spacer()
             HStack(spacing: 5) {
                 Text("\(value) \(Constants.General.days)")
-                    .foregroundColor(colorForLastRestart(value: value))
+                    .foregroundColor(color)
+                    .shadow(color: isGreen ? .black.opacity(0.4) : .clear, radius: 1, x: 0, y: 1)
                 Image(systemName: "clock.fill")
-                    .foregroundColor(colorForLastRestart(value: value))
+                    .foregroundColor(color)
+                    .shadow(color: isGreen ? .black.opacity(0.4) : .clear, radius: 1, x: 0, y: 1)
             }
             .font(.system(size: 14))
             .help(Constants.ToolTips.deviceLastRebooted)
         }
     }
 
-    /// Determine the color based on the number of days since the last restart
     private func colorForLastRestart(value: Int) -> Color {
         switch value {
         case 0...2:
             return .green
         case 3...7:
-            return .orange
+            return colorScheme == .light ? .orangeLight : .orange
         default:
-            return .red
+            return colorScheme == .light ? .redLight : .red
         }
     }
 }

--- a/SupportCompanion/Views/Cards/KSSOCard.swift
+++ b/SupportCompanion/Views/Cards/KSSOCard.swift
@@ -14,7 +14,7 @@ struct KSSOCard: View {
     var body: some View {
         VStack(alignment: .leading){
             if "" != appState.ssoInfoManager.kerberosSSO.username {
-                CustomCard(title: "\(Constants.CardTitle.kerberosSSO)", titleImageName: "lock.fill", content: {
+                CustomCard(title: "\(Constants.CardTitle.kerberosSSO)", titleImageName: "lock.fill", useMultiColor: false, content: {
                         VStack(alignment: .leading) {
                             CardData(info: appState.ssoInfoManager.kerberosSSO.toKeyValuePairs())
                         }

--- a/SupportCompanion/Views/Cards/PSSOCard.swift
+++ b/SupportCompanion/Views/Cards/PSSOCard.swift
@@ -15,7 +15,7 @@ struct PSSOCard: View {
     var body: some View {
         VStack(alignment: .leading){
             if "" != appState.ssoInfoManager.platformSSO.loginType {
-                CustomCard(title: "\(Constants.CardTitle.platformSSO)", titleImageName: "lock.fill", content: {
+                CustomCard(title: "\(Constants.CardTitle.platformSSO)", titleImageName: "lock.fill", useMultiColor: false, content: {
                         VStack(alignment: .leading) {
                             CardData(info: appState.ssoInfoManager.platformSSO.toKeyValuePairs())
                         }

--- a/SupportCompanion/Views/Cards/StorageDeviceManagementStack.swift
+++ b/SupportCompanion/Views/Cards/StorageDeviceManagementStack.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct StorageDeviceManagementStack: View {
     @ObservedObject var viewModel: CardGridViewModel
     @EnvironmentObject var appState: AppStateManager
-
+    @Environment(\.colorScheme) var colorScheme
     
     var body: some View {
         if !viewModel.isCardVisible(Constants.Cards.storageCardName) && !viewModel.isCardVisible(Constants.Cards.deviceManagementCardName) {
@@ -38,7 +38,9 @@ struct StorageDeviceManagementStack: View {
                                                     Text("\(String(format: "%.1f", appState.storageInfoManager.storageInfo.usage))% Used")
                                                     .font(.system(size: 14))}
                                             )
-                                            .tint(appState.storageInfoManager.storageInfo.percentageColor)
+                                            .tint(appState.storageInfoManager.storageInfo.usage < 50 ? Color.green
+                                                  : appState.storageInfoManager.storageInfo.usage < 80 ? (colorScheme == .light ? .orangeLight : .orange)
+                                                  : (colorScheme == .light ? .redLight : .red))
                                             .padding(.top)
                                         )
                                     }

--- a/SupportCompanion/Views/TransparentView.swift
+++ b/SupportCompanion/Views/TransparentView.swift
@@ -25,16 +25,22 @@ struct TransparentView: View {
 
             VStack(alignment: .leading) {
                 // Title for the Info View
-                Text(Constants.CardTitle.deviceInfo)
-                    .font(.title2)
-                    .bold()
-                    .foregroundColor(.white)
-                    .padding(.bottom, 10)
-                    .shadow(radius: 2)
+                if !appState.preferences.desktopInfoHideItems.contains("Category") {
+                    Text(Constants.CardTitle.deviceInfo)
+                        .font(.title2)
+                        .bold()
+                        .foregroundColor(.white)
+                        .padding(.bottom, 10)
+                        .shadow(radius: 2)
+                }
 
                 // Grouped Device Information
                 ForEach(Array(groupedDeviceInfoArray().enumerated()), id: \.1.0) { index, group in
-                    SectionHeaderTransparent(title: group.0) // Section title (e.g., "Hardware Specifications")
+                    SectionHeaderTransparent(
+                        title: group.0, 
+                        addHeader: shouldShowGategory(), 
+                        fontSize: CGFloat(appState.preferences.desktopInfoFontSize)
+                    ) // Section title (e.g., "Hardware Specifications")
                     VStack(alignment: .leading) {
                         ForEach(group.1.filter { !appState.preferences.desktopInfoHideItems.contains($0.key) }, id: \.key) { item in
                             deviceInfoRow(for: item)
@@ -44,7 +50,7 @@ struct TransparentView: View {
 
                     // Add a divider only if it's not the last group
                     if index < groupedDeviceInfoArray().count - 1 {
-                        Divider()
+                        shouldShowDivider()
                             .background(Color.white.opacity(0.2))
                             .shadow(radius: 2)
                             .padding(.vertical, 5)
@@ -53,22 +59,30 @@ struct TransparentView: View {
 
                 if appState.preferences.desktopInfoLevel > 3 && !appState.preferences.desktopInfoHideItems.contains("Storage"){
                     // Storage Section
-                    Divider()
+                    shouldShowDivider()
                         .background(Color.white.opacity(0.2))
                         .shadow(radius: 2)
                         .padding(.vertical, 5)
                     
-                    SectionHeaderTransparent(title: Constants.CardTitle.storage)
+                    SectionHeaderTransparent(
+                        title: Constants.CardTitle.storage, 
+                        addHeader: shouldShowGategory(), 
+                        fontSize: CGFloat(appState.preferences.desktopInfoFontSize)
+                    )
                     storageInfoSection()
                 }
                 
                 if appState.preferences.desktopInfoLevel > 4 && !appState.preferences.desktopInfoHideItems.contains("Support"){
-                    Divider()
+                    shouldShowDivider()
                         .background(Color.white.opacity(0.2))
                         .shadow(radius: 2)
                         .padding(.vertical, 5)
                     
-                    SectionHeaderTransparent(title: Constants.Support.Titles.support)
+                    SectionHeaderTransparent(
+                        title: Constants.Support.Titles.support, 
+                        addHeader: shouldShowGategory(), 
+                        fontSize: CGFloat(appState.preferences.desktopInfoFontSize)
+                    )
                     supportInfoSection()
                 }
             }
@@ -85,6 +99,16 @@ struct TransparentView: View {
             })
         }
         .frame(height: contentHeight)
+    }
+
+    private func shouldShowDivider() -> some View {
+        !appState.preferences.desktopInfoHideItems.contains("Dividers")
+            ? AnyView(Divider())
+            : AnyView(EmptyView())
+    }
+    
+    private func shouldShowGategory() -> Bool {
+        !appState.preferences.desktopInfoHideItems.contains("Category")
     }
     
     private func localizedHideCheck(_ standardKey: String) -> Bool {
@@ -231,6 +255,8 @@ struct TransparentView: View {
 
 struct SectionHeaderTransparent: View {
     let title: String
+    let addHeader: Bool
+    let fontSize: CGFloat
 
     // Computed property for the image name
     private var image: String {
@@ -251,13 +277,17 @@ struct SectionHeaderTransparent: View {
     }
 
     var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: image)
-            Text(title)
-                .font(.headline)
+        if addHeader {
+            HStack(spacing: 8) {
+                Image(systemName: image)
+                Text(title)
+                    .font(.system(size: fontSize))
+            }
+            .shadow(radius: 2)
+            .padding(.vertical, 5)
+        } else {
+            EmptyView()
         }
-        .shadow(radius: 2)
-        .padding(.vertical, 5)
     }
 }
 

--- a/SupportCompanion/Views/TransparentView.swift
+++ b/SupportCompanion/Views/TransparentView.swift
@@ -102,7 +102,7 @@ struct TransparentView: View {
     }
 
     private func shouldShowDivider() -> some View {
-        !appState.preferences.desktopInfoHideItems.contains("Dividers")
+        !appState.preferences.desktopInfoHideItems.contains("Divider")
             ? AnyView(Divider())
             : AnyView(EmptyView())
     }

--- a/build.zsh
+++ b/build.zsh
@@ -250,15 +250,15 @@ cp "$LA_PATH/payload/$LA_NAME" "$PKGBUILDDIR/payload/Library/LaunchAgents/$LA_NA
 
 check_exit_code "$?" "Error copying launch agent"
 
-create_pkg $BUNDLE_IDENTIFIER $AUTOMATED_SC_BUILD $PKGBUILDDIR "${BUILDSDIR}/SupportCompanion_suite-${AUTOMATED_SC_BUILD}.pkg" "/"
+create_pkg $BUNDLE_IDENTIFIER $AUTOMATED_SC_BUILD $PKGBUILDDIR "${BUILDSDIR}/SupportCompanion_Suite-${AUTOMATED_SC_BUILD}.pkg" "/"
     
-generate_dist_file $BUNDLE_IDENTIFIER $AUTOMATED_SC_BUILD $DIST_FILE "_suite"
+generate_dist_file $BUNDLE_IDENTIFIER $AUTOMATED_SC_BUILD $DIST_FILE "_Suite"
 
 run_product_build_sign $BUILDSDIR "${BUILDSDIR}/${APP_NAME}_Suite-${AUTOMATED_SC_BUILD}"
 
 notarize_and_staple "${BUILDSDIR}/${APP_NAME}_Suite-${AUTOMATED_SC_BUILD}.pkg"
 
-cp "${BUILDSDIR}/${APP_NAME}_suite-${AUTOMATED_SC_BUILD}.pkg" "${RELEASEDIR}/${APP_NAME}_suite-${AUTOMATED_SC_BUILD}.pkg"
+cp "${BUILDSDIR}/${APP_NAME}_Suite-${AUTOMATED_SC_BUILD}.pkg" "${RELEASEDIR}/${APP_NAME}_Suite-${AUTOMATED_SC_BUILD}.pkg"
 
 echo "Build complete: ${RELEASEDIR}/${APP_NAME}_Suite-${AUTOMATED_SC_BUILD}.pkg"
 


### PR DESCRIPTION
### Changed
- Added a softer shade of orange and red when light mode is enabled to improve visibility and readability.
- If launching the app using a URL scheme, the app will now exit **only** when `supportcompanion://` is used. This allows for the app to be started using a URL scheme and remain open when using `supportcompanion://home` or similar. Example:

Will exit when the window is closed:
```bash
open supportcompanion://
```

Will remain open when the window is closed:
```bash
open supportcompanion://home
```

### Added
- Option to hide Categories and Dividers on the Desktop Info view. This allows for a cleaner and more focused view of the information displayed. Example configuration:
```xml
<key>DesktopInfoHideItems</key>
<array>
    <string>Category</string>
    <string>Divider</string>
</array>
```

closes #59 