### PR TITLE
v2.2.1

### DIFF
--- a/.github/workflows/build_supportcompanion_prerelease.yml
+++ b/.github/workflows/build_supportcompanion_prerelease.yml
@@ -79,7 +79,7 @@ jobs:
           files: ${{github.workspace}}/release/*.pkg
 
       - name: Upload packages
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: packages
           path: release/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Even if `SoftwareUpdates` or `PendingAppUpdates` were hidden, the badge would still be displayed in the tray menu and dock. This has been fixed by checking if the widget is hidden before displaying the badge.
 
+### Added
+- A new option to set a custom branding tray menu icon by specifying a base64 string of the icon using `TrayMenuBrandingIcon`. Note that the icon should be a monochrome icon to fit the design of the tray menu.
+
 ## [2.2.0] - 2025-01-07
 ### Changed
 - A slight background has been added increasing visaibility of the text.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.1] - 2025-02-11
+## [2.2.1] - 2025-02-26
 ### Fixed
 - Even if `SoftwareUpdates` or `PendingAppUpdates` were hidden, the badge would still be displayed in the tray menu and dock. This has been fixed by checking if the widget is hidden before displaying the badge.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - A new option to set a custom branding tray menu icon by specifying a base64 string of the icon using `TrayMenuBrandingIcon`. Note that the icon should be a monochrome icon to fit the design of the tray menu.
 
+
+### Changed
+- Additional options to the rendering of brand logos has been added that allows for a higher quality rendering of the logo as it in some cases could look blurry or jagged.
+
 ## [2.2.0] - 2025-01-07
 ### Changed
 - A slight background has been added increasing visaibility of the text.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2025-02-11
+### Fixed
+- Even if `SoftwareUpdates` or `PendingAppUpdates` were hidden, the badge would still be displayed in the tray menu and dock. This has been fixed by checking if the widget is hidden before displaying the badge.
+
 ## [2.2.0] - 2025-01-07
 ### Changed
 - A slight background has been added increasing visaibility of the text.

--- a/SupportCompanion/AppDelegate.swift
+++ b/SupportCompanion/AppDelegate.swift
@@ -186,7 +186,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     class TrayMenuManager {
         static let shared = TrayMenuManager()
-        
+        let appStateManager = AppStateManager.shared
+        let fileManager = FileManager.default
         private var statusItem: NSStatusItem
 
         private init() {
@@ -196,8 +197,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
         func updateTrayIcon(hasUpdates: Bool) {
             let iconName = "MenuIcon"
-            guard let baseIcon = NSImage(named: iconName) else {
-                Logger.shared.logDebug("Failed to load tray icon: \(iconName)")
+            let iconPath = appStateManager.preferences.trayMenuBrandingIconPath
+            var baseIcon: NSImage?
+
+            if !iconPath.isEmpty && fileManager.fileExists(atPath: iconPath) {
+                baseIcon = NSImage(contentsOfFile: iconPath)
+            } else {
+                baseIcon = NSImage(named: iconName)
+            }
+
+            guard let baseIcon = baseIcon else {
+                Logger.shared.logError("Error: Failed to load tray menu icon")
                 return
             }
 

--- a/SupportCompanion/AppDelegate.swift
+++ b/SupportCompanion/AppDelegate.swift
@@ -197,11 +197,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
         func updateTrayIcon(hasUpdates: Bool) {
             let iconName = "MenuIcon"
-            let iconPath = appStateManager.preferences.trayMenuBrandingIconPath
+            let base64Logo = appStateManager.preferences.trayMenuBrandingIcon
+            var showLogo = false
             var baseIcon: NSImage?
 
-            if !iconPath.isEmpty && fileManager.fileExists(atPath: iconPath) {
-                baseIcon = NSImage(contentsOfFile: iconPath)
+            showLogo = loadLogo(base64Logo: base64Logo)
+            if showLogo {
+                baseIcon = NSImage(data: Data(base64Encoded: base64Logo)!)
             } else {
                 baseIcon = NSImage(named: iconName)
             }

--- a/SupportCompanion/ContentView.swift
+++ b/SupportCompanion/ContentView.swift
@@ -31,8 +31,11 @@ struct ContentView: View {
                 if showLogo, let logo = brandLogo {
                     logo
                         .resizable()
+                        .interpolation(.high)
+                        .antialiased(true)
                         .scaledToFit()
                         .frame(maxWidth: 230)
+                        .drawingGroup()
                         .fixedSize(horizontal: false, vertical: true)
                         .padding(.top, 20) // Minimal padding
                         .padding(.horizontal, 20)

--- a/SupportCompanion/Info.plist
+++ b/SupportCompanion/Info.plist
@@ -19,9 +19,9 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.2.0</string>
+	<string>2.2.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/SupportCompanion/Preferences.swift
+++ b/SupportCompanion/Preferences.swift
@@ -80,6 +80,8 @@ class Preferences: ObservableObject {
     @AppStorage("CustomCardsMenuLabel") var customCardsMenuLabel: String = ""
     
     @AppStorage("CustomCardsMenuIcon") var customCardsMenuIcon: String = ""
+
+    @AppStorage("TrayMenuBrandingIconPath") var trayMenuBrandingIconPath: String = ""
     
     // MARK: - Actions
     

--- a/SupportCompanion/Preferences.swift
+++ b/SupportCompanion/Preferences.swift
@@ -81,7 +81,7 @@ class Preferences: ObservableObject {
     
     @AppStorage("CustomCardsMenuIcon") var customCardsMenuIcon: String = ""
 
-    @AppStorage("TrayMenuBrandingIconPath") var trayMenuBrandingIconPath: String = ""
+    @AppStorage("TrayMenuBrandingIcon") var trayMenuBrandingIcon: String = ""
     
     // MARK: - Actions
     

--- a/SupportCompanion/Services/NotificationService.swift
+++ b/SupportCompanion/Services/NotificationService.swift
@@ -155,7 +155,10 @@ class BadgeManager {
     private func updateBadge() {
         DispatchQueue.main.async {
             if self.badgeCount > 0 {
-                NSApplication.shared.dockTile.showsApplicationBadge = true
+                let prefs = AppStateManager.shared.preferences
+                let hasPendingUpdates = !prefs.hiddenCards.contains("PendingAppUpdates") && AppStateManager.shared.pendingUpdatesCount > 0
+                let hasSoftwareUpdates = !prefs.hiddenActions.contains("SoftwareUpdates") && AppStateManager.shared.systemUpdateCache.count > 0
+                NSApplication.shared.dockTile.showsApplicationBadge = hasPendingUpdates || hasSoftwareUpdates
                 NSApplication.shared.dockTile.badgeLabel = nil
                 NSApplication.shared.dockTile.badgeLabel = String(self.badgeCount)
             } else {

--- a/SupportCompanion/Services/NotificationService.swift
+++ b/SupportCompanion/Services/NotificationService.swift
@@ -158,9 +158,15 @@ class BadgeManager {
                 let prefs = AppStateManager.shared.preferences
                 let hasPendingUpdates = !prefs.hiddenCards.contains("PendingAppUpdates") && AppStateManager.shared.pendingUpdatesCount > 0
                 let hasSoftwareUpdates = !prefs.hiddenActions.contains("SoftwareUpdates") && AppStateManager.shared.systemUpdateCache.count > 0
-                NSApplication.shared.dockTile.showsApplicationBadge = hasPendingUpdates || hasSoftwareUpdates
-                NSApplication.shared.dockTile.badgeLabel = nil
-                NSApplication.shared.dockTile.badgeLabel = String(self.badgeCount)
+                if hasPendingUpdates || hasSoftwareUpdates {
+                    NSApplication.shared.dockTile.showsApplicationBadge = true
+                    NSApplication.shared.dockTile.badgeLabel = nil
+                    NSApplication.shared.dockTile.badgeLabel = String(self.badgeCount)
+                } else {
+                    NSApplication.shared.dockTile.showsApplicationBadge = false
+                    NSApplication.shared.dockTile.badgeLabel = nil
+                }
+
             } else {
                 NSApplication.shared.dockTile.badgeLabel = nil
                 NSApplication.shared.dockTile.showsApplicationBadge = false

--- a/SupportCompanion/ViewModels/PendingIntuneUpdatesManager.swift
+++ b/SupportCompanion/ViewModels/PendingIntuneUpdatesManager.swift
@@ -90,7 +90,7 @@ class PendingIntuneUpdatesManager {
                     self.appState.pendingUpdatesCount = updates
                 }
             }
-            if updates > 0 {
+            if updates > 0 && !appState.preferences.hiddenCards.contains("PendingAppUpdates") {
                 NotificationService(appState: appState).sendNotification(
                     message: appState.preferences.appUpdateNotificationMessage,
                     buttonText: appState.preferences.appUpdateNotificationButtonText,

--- a/SupportCompanion/ViewModels/PendingMunkiUpdatesManager.swift
+++ b/SupportCompanion/ViewModels/PendingMunkiUpdatesManager.swift
@@ -120,7 +120,7 @@ class PendingMunkiUpdatesManager {
                     self.appState.pendingUpdatesCount = updates
                 }
             }
-            if updates > 0 {
+            if updates > 0 && !appState.preferences.hiddenCards.contains("PendingAppUpdates") {
                 NotificationService(appState: appState).sendNotification(
                     message: appState.preferences.appUpdateNotificationMessage,
                     buttonText: appState.preferences.appUpdateNotificationButtonText,

--- a/SupportCompanion/ViewModels/SystemUpdatesManager.swift
+++ b/SupportCompanion/ViewModels/SystemUpdatesManager.swift
@@ -38,7 +38,7 @@ class SystemUpdatesManager: ObservableObject {
         monitorTask = Task {
             while !Task.isCancelled {
                 do {
-                    let result = await ActionHelpers.getSystemUpdateStatus(sendNotification: true)
+                    let result = await ActionHelpers.getSystemUpdateStatus(sendNotification: !appState.preferences.hiddenActions.contains("SoftwareUpdates"))
                     switch result {
                     case .success(let (count, updates)):
                         if count != self.previousUpdateCount {

--- a/SupportCompanion/Views/TrayMenu.swift
+++ b/SupportCompanion/Views/TrayMenu.swift
@@ -27,6 +27,9 @@ struct TrayMenuView: View {
             if showLogo, let logo = brandLogo {
                     logo
                         .resizable()
+                        .interpolation(.high)
+                        .antialiased(true)
+                        .drawingGroup()
                         .scaledToFit()
                         .frame(maxWidth: 150)
                         .fixedSize(horizontal: false, vertical: true)

--- a/build.zsh
+++ b/build.zsh
@@ -109,7 +109,7 @@ elif [ "$CONFIGURATION" = "Release" ]; then
     SIGNING_IDENTITY_APP="Developer ID Application: Mac Admins Open Source (T4SK8ZXCXG)"
     SIGNING_IDENTITY="Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)"
     KEYCHAIN_PROFILE="supportcompanion"
-    XCODE_PATH="/Applications/Xcode_16.app"
+    XCODE_PATH="/Applications/Xcode_16.2.app"
     TEAM_ID="T4SK8ZXCXG"
 else
     echo "No configuration set, exiting..."


### PR DESCRIPTION
### Fixed
- Even if SoftwareUpdates or PendingAppUpdates were hidden, the badge would still be displayed in the tray menu and dock. This has been fixed by checking if the widget is hidden before displaying the badge.
### Added
- A new option to set a custom branding tray menu icon by specifying a base64 string of the icon using TrayMenuBrandingIcon. Note that the icon should be a monochrome icon to fit the design of the tray menu.
### Changed
- Additional options to the rendering of brand logos has been added that allows for a higher quality rendering of the logo as it in some cases could look blurry or jagged.